### PR TITLE
feat: add JSON Schema validation (2/N: HTTP handler)

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/medibloc/panacea-data-market-validator/types"
 	"github.com/medibloc/panacea-data-market-validator/utils"
+	"github.com/medibloc/panacea-data-market-validator/validation"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 )
@@ -29,15 +30,24 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Println(data)
 
-	// get deal information from panacea
+	// TODO: get deal information from panacea
+	desiredSchemaURI := "https://json.schemastore.org/github-issue-forms.json"
 
-	// check if data validator is trusted or not
+	// TODO: check if data validator is trusted or not
 
 	// validate data (schema check)
+	if err := validation.ValidateJSONSchema(data, desiredSchemaURI); err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusForbidden)
+		if _, e := w.Write([]byte(err.Error())); e != nil {
+			log.Error("response write failed: ", e)
+		}
+		return
+	}
 
-	// encrypt and store data
+	// TODO: encrypt and store data
 
-	// sign certificate
+	// TODO: sign certificate
 
 	marshaledResp, err := json.Marshal(resp)
 	if err != nil {

--- a/utils/data_reader.go
+++ b/utils/data_reader.go
@@ -1,14 +1,14 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/medibloc/panacea-data-market-validator/types"
+	"io/ioutil"
 	"net/http"
 )
 
 // ReadData reads data from request body
-func ReadData(r *http.Request) (interface{}, error) {
+func ReadData(r *http.Request) ([]byte, error) {
 
 	// content type check from header
 	contentType := r.Header.Get("Content-Type")
@@ -16,12 +16,10 @@ func ReadData(r *http.Request) (interface{}, error) {
 		return nil, types.ErrUnsupportedMediaType
 	}
 
-	var data interface{}
-
-	err := json.NewDecoder(r.Body).Decode(&data)
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, fmt.Errorf("request body decode failed: %w", err)
+		return nil, fmt.Errorf("failed to read HTTP request body: %w", err)
 	}
 
-	return data, nil
+	return body, nil
 }


### PR DESCRIPTION
Modified the HTTP POST handler to call the JSON Schema validation which was implemented in #2 

Follow-up PR: Refactor error handling.