### PR TITLE
docs: fix 'Running' bash script to read the log level correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ make install
 ## Running
 
 ```bash
-DATAVAL_LOG_LEVEL=info \  # panic, fatal, error, warn, info, debug, trace
+# Supported log levels: panic, fatal, error, warn, info, debug, trace
+DATAVAL_LOG_LEVEL=info \
 DATAVAL_HTTP_LADDR=0.0.0.0:8080 \
 DATAVAL_PANACEA_GRPC_ADDR=0.0.0.0:9090 \
 DATAVAL_VALIDATOR_MNEMONIC={Your mnemonic} \


### PR DESCRIPTION
The example bash script for running the application that I've written had a bug(?).
Because of the comment that was at the end of line, the `DATAVAL_LOG_LEVEL` hasn't been read by the application.
In general, it's okay to put comments at the end of line in bash. But, only if the line ends with a backslash(`\`), comments shouldn't be at the end of line. So fucking tricky bash.