### PR TITLE
build: install `git` in Dockerfile for `go build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS build-env
 
 # Install minimum necessary dependencies,
-RUN apk add --no-cache ca-certificates build-base
+RUN apk add --no-cache ca-certificates build-base git
 
 WORKDIR /src
 


### PR DESCRIPTION
Since `golang:1.18-alpine`, it seems that `git` isn't included in the docker image.
Because of that, our CI has been being failed with the following error:
```
Step 7/11 : RUN BUILD_TAGS=muslc make build
 ---> Running in ee0308c455fe
go build -mod=readonly -tags "muslc" -o ./build/datavald ./cmd/datavald
go: downloading github.com/sirupsen/logrus v1.8.1
...
go: downloading github.com/mimoo/StrobeGo v0.0.0-20[181](https://github.com/medibloc/panacea-data-market-validator/runs/5581804456?check_suite_focus=true#step:6:181)01616[230](https://github.com/medibloc/panacea-data-market-validator/runs/5581804456?check_suite_focus=true#step:6:230)0-f8f6d4d2b643
go: missing Git command. See https://golang.org/s/gogetcmd
error obtaining VCS status: exec: "git": executable file not found in $PATH
```
