### PR TITLE
feat: add `/v0/tee/attestation-token` API + script for enclave tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ build/
 
 # Dotenv file that is usually used for docker-compose
 .env
-enclave.json
+
+# Enclave-related files
+./enclave.json
 *.pem

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,8 @@ all: build test install
 build: go.sum
 	$(GOBIN) build -mod=readonly $(BUILD_FLAGS) -o $(OUT_DIR)/datavald ./cmd/datavald
 
-UNIT_TESTS=$(shell go list ./... | grep -v /e2e)  # except e2e/*_test.go
 test:
-	$(GOBIN) test -v $(UNIT_TESTS)
+	GOBIN=$(GOBIN) ./run_gotest.sh
 
 # Set env vars used by ./e2e/docker-compose.yml before running this target (recommended to use .env file).
 e2e-test:

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euox pipefail
+
+SCRIPT_DIR=$(cd `dirname $0` && pwd)
+
+echo "GOBIN: ${GOBIN}"
+
+# NOTE: Please update this array if necessary
+PKG_PREFIX="github.com/medibloc/panacea-data-market-validator"
+TEST_PKGS_WITH_EGO=(
+    "${PKG_PREFIX}/server/tee"
+)
+
+#####################################################################
+echo "[Step 1] Running unit tests that don't require EGo..."
+
+TEST_PKGS_WITHOUT_EGO=$(go list ./... | grep -v /e2e)  # except e2e/*_test.go
+for pkg in ${TEST_PKGS_WITH_EGO[@]}; do
+    TEST_PKGS_WITHOUT_EGO=$(echo "${TEST_PKGS_WITHOUT_EGO}" | grep -v ${pkg})
+done
+
+${GOBIN} test -v ${TEST_PKGS_WITHOUT_EGO}
+
+
+#####################################################################
+echo "[Step 2] Running unit tests that require EGo..."
+
+if [ ${GOBIN} != "ego-go" ]; then
+    echo "Skipping: EGo disabled"
+    exit 0
+fi
+
+
+# Compile the binary of each test package but do not run it.
+# Instead, sign the test binary for EGo and run it with the `ego` command.
+# NOTE: We need this 'for' loop because Go doesn't support building a test binary for all packages.
+for pkg in ${TEST_PKGS_WITH_EGO}; do
+    PKG_DIR=${pkg#$PKG_PREFIX}
+    ENCLAVE_JSON_PATH="${SCRIPT_DIR}/${PKG_DIR}/testdata/enclave.json"
+    TEST_BIN_PATH="./$(jq -c '.exe' -r ${ENCLAVE_JSON_PATH})"
+
+    ${GOBIN} test -c -o ${TEST_BIN_PATH} ${pkg}   # Compile the test binary but do not run it
+    ego sign ${ENCLAVE_JSON_PATH}                 # Sign the test binary for EGo
+
+    # Run the test binary with env vars
+    EDG_TEST_ENCLAVE_SIGNER_ID_HEX=$(ego signerid ./public.pem) \
+        ego run ${TEST_BIN_PATH} -test.v
+
+    rm -f ${TEST_BIN_PATH}
+done
+
+
+

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -euox pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
 echo "GOBIN: ${GOBIN}"
 
 # NOTE: Please update this array if necessary
-PKG_PREFIX="github.com/medibloc/panacea-data-market-validator"
+PKG_PREFIX=$(grep '^module ' ./go.mod | awk "{print \$2}")
 TEST_PKGS_WITH_EGO=(
     "${PKG_PREFIX}/server/tee"
 )

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -36,7 +36,7 @@ fi
 # Instead, sign the test binary for EGo and run it with the `ego` command.
 # NOTE: We need this 'for' loop because Go doesn't support building a test binary for all packages.
 for pkg in ${ENCLAVE_TEST_PKGS}; do
-    PKG_DIR=${pkg#$PKG_PREFIX}
+    PKG_DIR=${pkg#$PKG_PREFIX}  # truncate the prefix
     ENCLAVE_JSON_PATH="${SCRIPT_DIR}/${PKG_DIR}/testdata/enclave.json"
     TEST_BIN_PATH="./$(jq -c '.exe' -r ${ENCLAVE_JSON_PATH})"
 

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -8,23 +8,23 @@ echo "GOBIN: ${GOBIN}"
 
 # NOTE: Please update this array if necessary
 PKG_PREFIX=$(grep '^module ' ./go.mod | awk "{print \$2}")
-TEST_PKGS_WITH_EGO=(
+ENCLAVE_TEST_PKGS=(
     "${PKG_PREFIX}/server/tee"
 )
 
 #####################################################################
-echo "[Step 1] Running unit tests that don't require EGo..."
+echo "[Step 1] Running non-enclave tests..."
 
-TEST_PKGS_WITHOUT_EGO=$(go list ./... | grep -v /e2e)  # except e2e/*_test.go
-for pkg in ${TEST_PKGS_WITH_EGO[@]}; do
-    TEST_PKGS_WITHOUT_EGO=$(echo "${TEST_PKGS_WITHOUT_EGO}" | grep -v ${pkg})
+NON_ENCLAVE_TEST_PKGS=$(go list ./... | grep -v /e2e)  # except e2e/*_test.go
+for pkg in ${ENCLAVE_TEST_PKGS[@]}; do
+    NON_ENCLAVE_TEST_PKGS=$(echo "${NON_ENCLAVE_TEST_PKGS}" | grep -v ${pkg})
 done
 
-${GOBIN} test -v ${TEST_PKGS_WITHOUT_EGO}
+${GOBIN} test -v ${NON_ENCLAVE_TEST_PKGS}
 
 
 #####################################################################
-echo "[Step 2] Running unit tests that require EGo..."
+echo "[Step 2] Running enclave tests..."
 
 if [ ${GOBIN} != "ego-go" ]; then
     echo "Skipping: EGo disabled"
@@ -35,7 +35,7 @@ fi
 # Compile the binary of each test package but do not run it.
 # Instead, sign the test binary for EGo and run it with the `ego` command.
 # NOTE: We need this 'for' loop because Go doesn't support building a test binary for all packages.
-for pkg in ${TEST_PKGS_WITH_EGO}; do
+for pkg in ${ENCLAVE_TEST_PKGS}; do
     PKG_DIR=${pkg#$PKG_PREFIX}
     ENCLAVE_JSON_PATH="${SCRIPT_DIR}/${PKG_DIR}/testdata/enclave.json"
     TEST_BIN_PATH="./$(jq -c '.exe' -r ${ENCLAVE_JSON_PATH})"

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/medibloc/panacea-data-market-validator/server/datapool"
 	"github.com/medibloc/panacea-data-market-validator/server/service"
 	"github.com/medibloc/panacea-data-market-validator/server/tee"
-	attestation "github.com/medibloc/panacea-data-market-validator/tee"
 
 	"github.com/gorilla/mux"
 	"github.com/medibloc/panacea-data-market-validator/config"
@@ -25,15 +24,6 @@ func Run(conf *config.Config) {
 		log.Panicf("failed to create service: %v", err)
 	}
 	defer svc.Close()
-
-	log.Info("Generating a new certificate.")
-	cert, priv, err := attestation.CreateTLSCertificate()
-	if err != nil {
-		log.Panicf("failed to get certificate: %v", err)
-	}
-	// TODO This certificate and key are generated or read when the server starts up.
-	// But since there is no place to use it yet, I'll just take a picture of it as a log.
-	log.Info(cert, priv)
 
 	router := mux.NewRouter()
 	datadeal.RegisterHandlers(svc, router)

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"net/http"
 	"os"
@@ -36,15 +35,12 @@ func Run(conf *config.Config) {
 		Addr:         conf.HTTPListenAddr,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{*svc.TLSCert},
-		},
 	}
 
 	httpServerErrCh := make(chan error, 1)
 	go func() {
 		log.Infof("👻 Data Validator Server Started 🎃: Serving %s", server.Addr)
-		if err := server.ListenAndServeTLS("", ""); err != nil {
+		if err := server.ListenAndServe(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				httpServerErrCh <- err
 			} else {

--- a/server/server.go
+++ b/server/server.go
@@ -44,7 +44,7 @@ func Run(conf *config.Config) {
 	httpServerErrCh := make(chan error, 1)
 	go func() {
 		log.Infof("👻 Data Validator Server Started 🎃: Serving %s", server.Addr)
-		if err := server.ListenAndServe(); err != nil {
+		if err := server.ListenAndServeTLS("", ""); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				httpServerErrCh <- err
 			} else {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"os"
@@ -35,6 +36,9 @@ func Run(conf *config.Config) {
 		Addr:         conf.HTTPListenAddr,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{*svc.TLSCert},
+		},
 	}
 
 	httpServerErrCh := make(chan error, 1)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/medibloc/panacea-data-market-validator/config"
@@ -14,7 +15,7 @@ type Service struct {
 	ValidatorAccount *panacea.ValidatorAccount
 	Store            store.S3Store
 	PanaceaClient    *panacea.GrpcClient
-	TLSCertificate   []byte
+	TLSCert          *tls.Certificate
 }
 
 func New(conf *config.Config) (*Service, error) {
@@ -33,7 +34,7 @@ func New(conf *config.Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create PanaceaGRPCClient: %w", err)
 	}
 
-	tlsCertificate, _, err := tee.CreateTLSCertificate()
+	tlsCert, err := tee.CreateTLSCertificate()
 	if err != nil {
 		panaceaClient.Close()
 		return nil, fmt.Errorf("failed to create TLS certificate: %w", err)
@@ -44,7 +45,7 @@ func New(conf *config.Config) (*Service, error) {
 		ValidatorAccount: validatorAccount,
 		Store:            s3Store,
 		PanaceaClient:    panaceaClient,
-		TLSCertificate:   tlsCertificate,
+		TLSCert:          tlsCert,
 	}, nil
 }
 

--- a/server/tee/testdata/enclave.json
+++ b/server/tee/testdata/enclave.json
@@ -1,0 +1,17 @@
+{
+  "exe": "tee.test",
+  "key": "private.pem",
+  "debug": true,
+  "heapSize": 512,
+  "executableHeap": false,
+  "productID": 1,
+  "securityVersion": 1,
+  "mounts": null,
+  "env": null,
+  "files": [
+    {
+      "source": "/etc/ssl/certs/ca-certificates.crt",
+      "target": "/etc/ssl/certs/ca-certificates.crt"
+    }
+  ]
+}

--- a/server/tee/token_handler.go
+++ b/server/tee/token_handler.go
@@ -8,9 +8,13 @@ import (
 )
 
 func (svc *teeService) handleToken(writer http.ResponseWriter, request *http.Request) {
-	// TODO: Consider creating a Azure attestation token at once when the process is started,
+	// TODO:
+	// Consider creating a Azure attestation token at once when the process is started,
 	// rather than whenever HTTP clients call 'GET ../attestation-token'.
-	// It's related to the 'exp: 8h' of JWT that Azure sets. It means that we need to handle the recreation of Azure attestation token.
+	// It would be good for reducing the overload of MAA.
+	// If so, we must keep in mind that the 'exp' of JWT that MAA sets is 8H.
+	// But, the current strategy is not bad in perspective of the MAA overload,
+	// since HTTP clients must communicate with MAA to verify JWT anyway.
 	jwt, err := tee.CreateAzureAttestationToken(svc.TLSCertificate, svc.Conf.EnclaveAttestationProviderURL)
 	if err != nil {
 		log.Errorf("failed to create Azure attestation token: %v", err)

--- a/server/tee/token_handler.go
+++ b/server/tee/token_handler.go
@@ -15,7 +15,7 @@ func (svc *teeService) handleToken(writer http.ResponseWriter, request *http.Req
 	// If so, we must keep in mind that the 'exp' of JWT that MAA sets is 8H.
 	// But, the current strategy is not bad in perspective of the MAA overload,
 	// since HTTP clients must communicate with MAA to verify JWT anyway.
-	jwt, err := tee.CreateAzureAttestationToken(svc.TLSCertificate, svc.Conf.EnclaveAttestationProviderURL)
+	jwt, err := tee.CreateAzureAttestationToken(svc.TLSCert.Certificate[0], svc.Conf.EnclaveAttestationProviderURL)
 	if err != nil {
 		log.Errorf("failed to create Azure attestation token: %v", err)
 		http.Error(writer, "failed to create attestation token", http.StatusInternalServerError)

--- a/server/tee/token_handler.go
+++ b/server/tee/token_handler.go
@@ -1,8 +1,25 @@
 package tee
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/medibloc/panacea-data-market-validator/tee"
+	log "github.com/sirupsen/logrus"
+)
 
 func (svc *teeService) handleToken(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me
-	panic("implement me")
+	// TODO: Consider creating a Azure attestation token at once when the process is started,
+	// rather than whenever HTTP clients call 'GET ../attestation-token'.
+	// It's related to the 'exp: 8h' of JWT that Azure sets. It means that we need to handle the recreation of Azure attestation token.
+	jwt, err := tee.CreateAzureAttestationToken(svc.TLSCertificate, svc.Conf.EnclaveAttestationProviderURL)
+	if err != nil {
+		log.Errorf("failed to create Azure attestation token: %v", err)
+		http.Error(writer, "failed to create attestation token", http.StatusInternalServerError)
+		return
+	}
+	log.Debugf("Azure attestation token created: %v", jwt)
+
+	writer.WriteHeader(http.StatusOK)
+	writer.Header().Set("Content-Type", "application/jwt")
+	writer.Write([]byte(jwt))
 }

--- a/server/tee/token_handler_test.go
+++ b/server/tee/token_handler_test.go
@@ -26,12 +26,12 @@ func TestHandleToken(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	// Prepare a service struct and execute the HTTP request
-	tlsCert, _, err := tee.CreateTLSCertificate()
+	tlsCert, err := tee.CreateTLSCertificate()
 	require.NoError(t, err)
 	svc := &teeService{
 		&service.Service{
-			Conf:           &config.Config{EnclaveAttestationProviderURL: "https://shareduks.uks.attest.azure.net"},
-			TLSCertificate: tlsCert,
+			Conf:    &config.Config{EnclaveAttestationProviderURL: "https://shareduks.uks.attest.azure.net"},
+			TLSCert: tlsCert,
 		},
 	}
 	svc.handleToken(recorder, req)

--- a/server/tee/token_handler_test.go
+++ b/server/tee/token_handler_test.go
@@ -1,0 +1,58 @@
+package tee
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/edgelesssys/ego/attestation"
+	"github.com/medibloc/panacea-data-market-validator/config"
+	"github.com/medibloc/panacea-data-market-validator/server/service"
+	"github.com/medibloc/panacea-data-market-validator/tee"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleToken(t *testing.T) {
+	// Load env vars for testing
+	enclaveSignerID, err := hex.DecodeString(os.Getenv("EDG_TEST_ENCLAVE_SIGNER_ID_HEX"))
+	require.NoError(t, err)
+
+	// Make a HTTP request and a HTTP server simulator (recorder)
+	req := httptest.NewRequest(http.MethodGet, "/v0/tee/attestation-token", nil)
+	recorder := httptest.NewRecorder()
+
+	// Prepare a service struct and execute the HTTP request
+	tlsCert, _, err := tee.CreateTLSCertificate()
+	require.NoError(t, err)
+	svc := &teeService{
+		&service.Service{
+			Conf:           &config.Config{EnclaveAttestationProviderURL: "https://shareduks.uks.attest.azure.net"},
+			TLSCertificate: tlsCert,
+		},
+	}
+	svc.handleToken(recorder, req)
+
+	// Get the HTTP response and verify it
+	res := recorder.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	attestationTokenBytes, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	report, err := attestation.VerifyAzureAttestationToken(string(attestationTokenBytes), svc.Conf.EnclaveAttestationProviderURL)
+	require.NoError(t, err)
+	t.Log("Azure attestation token verified")
+
+	// Verify report values with that were defined in the enclave.json
+	// and that were included into the test binary during build.
+	require.Equal(t, []byte(enclaveSignerID), report.SignerID)
+	require.Equal(t, uint16(1), binary.LittleEndian.Uint16(report.ProductID))
+	require.Equal(t, uint(1), report.SecurityVersion)
+	t.Log("Attestation report verified")
+}

--- a/tee/attestation_test.go
+++ b/tee/attestation_test.go
@@ -1,19 +1,24 @@
 package tee
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestCreateTLSCertificate(T *testing.T) {
-	certBytes, priv, err := CreateTLSCertificate()
-	require.NoError(T, err)
+func TestCreateTLSCertificate(t *testing.T) {
+	tlsCert, err := CreateTLSCertificate()
+	require.NoError(t, err)
 
-	cert, err := x509.ParseCertificate(certBytes)
-	require.NoError(T, err)
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	require.NoError(t, err)
 
-	require.Equal(T, "DataValidator", cert.Subject.CommonName)
-	require.Equal(T, priv.Public(), cert.PublicKey)
-	require.Equal(T, x509.RSA, cert.PublicKeyAlgorithm)
+	rsaPrivKey, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
+	require.True(t, ok)
+
+	require.Equal(t, "DataValidator", cert.Subject.CommonName)
+	require.Equal(t, rsaPrivKey.Public(), cert.PublicKey)
+	require.Equal(t, x509.RSA, cert.PublicKeyAlgorithm)
 }


### PR DESCRIPTION
Closes #45 

- Added the `/v0/tee/attestation-token` API
- Added a script for running unit tests with EGo

TODO:
- refactor: [consider merging `../server/tee` and `../tee` packages into one package](https://github.com/medibloc/panacea-data-market-validator/pull/57#discussion_r833906778).