### PR TITLE
fix: Fix Proto Marshal JSON

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -1,22 +1,19 @@
 package codec
 
 import (
-	"bytes"
+	"encoding/json"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"strings"
 )
 
 func ProtoMarshalJSON(msg proto.Message) ([]byte, error) {
-	jm := &jsonpb.Marshaler{}
-
-	buf := new(bytes.Buffer)
-
-	if err := jm.Marshal(buf, msg); err != nil {
+	marshaledResp, err := json.Marshal(msg)
+	if err != nil {
 		return nil, err
 	}
 
-	return buf.Bytes(), nil
+	return marshaledResp, nil
 }
 
 func ProtoUnmarshalJSON(bz []byte, ptr proto.Message) error {


### PR DESCRIPTION
When I did manual test, there has an issue to make data certificate.
When marshaling the data certificate file, the file was marshaled as following:
```json
{
    "unsignedCert": {
        "poolId": "1",
        "round": "1",
        "dataHash": "......",
        "dataValidator": "......",
        "requester": "......"
    },
    "signature": "......."
}
```

The each field must be marshaled as snake case, and the `pool_Id` and `round` fields data type should be `uint64`.
However, The `jsonpb` package marshaled a `uint64` field to `string`.
So, I changed the `ProtoMarshalJSON` function using `encoding/json` go standard library.

As a result, It was marshaled well as I wanted
```json
{
    "unsigned_cert": {
        "pool_id": 1,
        "round": 1,
        "data_hash": "......",
        "data_validator": "......",
        "requester": "......"
    },
    "signature": "......"
}
```