### PR TITLE
feat: add middleware for authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/medibloc/panacea-core/v2 v2.0.3-0.20220418010037-6747eba578f0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
@@ -589,8 +590,6 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=

--- a/panacea/grpc_client.go
+++ b/panacea/grpc_client.go
@@ -18,12 +18,26 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+type GrpcClientI interface {
+	GetPubKey(panaceaAddr string) (types.PubKey, error)
+
+	GetAccount(panaceaAddr string) (authtypes.AccountI, error)
+
+	GetDeal(id string) (datadealtypes.Deal, error)
+
+	GetRegisteredDataValidator(address string) (*datapooltypes.DataValidator, error)
+
+	GetPool(id string) (datapooltypes.Pool, error)
+
+	Close() error
+}
+
 type GrpcClient struct {
 	conn              *grpc.ClientConn
 	interfaceRegistry sdk.InterfaceRegistry
 }
 
-func NewGrpcClient(conf *config.Config) (*GrpcClient, error) {
+func NewGrpcClient(conf *config.Config) (GrpcClientI, error) {
 	log.Infof("dialing to Panacea gRPC endpoint: %s", conf.Panacea.GRPCAddr)
 	conn, err := grpc.Dial(conf.Panacea.GRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/server/middleware/auth/authentication.go
+++ b/server/middleware/auth/authentication.go
@@ -1,0 +1,220 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"github.com/medibloc/panacea-data-market-validator/server/service"
+	"github.com/medibloc/panacea-data-market-validator/types"
+	"github.com/medibloc/panacea-data-market-validator/validation"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const (
+	prefixType = "Signature"
+
+	Algorithm = "algorithm"
+	KeyId     = "keyId"
+	Nonce     = "nonce"
+	Signature = "signature"
+)
+
+var authorizationHeaders = []string{Algorithm, KeyId, Nonce, Signature}
+var authenticateHeaders = []string{Algorithm, KeyId, Nonce}
+
+type AuthenticationMiddleware struct {
+	service *service.Service
+	url     map[string][]string
+}
+
+func NewMiddleware(svc *service.Service) *AuthenticationMiddleware {
+	return &AuthenticationMiddleware{
+		service: svc,
+		url:     make(map[string][]string),
+	}
+}
+
+func (amw *AuthenticationMiddleware) AddURL(path string, methods ...string) {
+	// Router is only used to convert path to regex.
+	pathRegex, err := mux.NewRouter().Path(path).Methods(http.MethodGet).GetPathRegexp()
+	if err != nil {
+		panic(err)
+	}
+	m, ok := amw.url[pathRegex]
+	if !ok {
+		amw.url[pathRegex] = methods
+	} else {
+		amw.url[pathRegex] = append(m, methods...)
+	}
+}
+
+func (amw *AuthenticationMiddleware) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// if it is not an authentication URL, the authentication check is not performed.
+		if !amw.isAuthenticationURL(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		sigAuthParts, err := ParseSignatureAuthorizationParts(r.Header.Get("Authorization"))
+		//signatureAuthentication, err := parseSignatureAuthentication(r)
+		if err != nil {
+			// result code to 400. Bad request
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		err = basicValidate(sigAuthParts)
+		if err != nil {
+			// result code to 400. Bad request
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if sigAuthParts[Nonce] == "" {
+			err = amw.generateAuthenticationAndSetHeader(w, sigAuthParts)
+			if err != nil {
+				log.Error("failed to generate authentication", err)
+				http.Error(w, "failed to generate authentication", http.StatusInternalServerError)
+			}
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+
+		cache := amw.service.Cache
+		auth := cache.Get(sigAuthParts[KeyId], sigAuthParts[Nonce])
+		if auth == nil {
+			// expired
+			err = amw.generateAuthenticationAndSetHeader(w, sigAuthParts)
+			if err != nil {
+				log.Error("failed to generate authentication", err)
+				http.Error(w, "failed to generate authentication", http.StatusInternalServerError)
+			}
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+
+		nonce := sigAuthParts[Nonce]
+		signature, err := base64.StdEncoding.DecodeString(sigAuthParts[Signature])
+		if err != nil {
+			http.Error(w, "failed to decode signature", http.StatusBadRequest)
+			return
+		}
+
+		requesterAddress := sigAuthParts[KeyId]
+		pubKey, err := amw.service.PanaceaClient.GetPubKey(requesterAddress)
+		if err != nil {
+			log.Error(fmt.Sprintf("failed to get the account's public key account: %s", requesterAddress), err)
+			http.Error(w, "failed to get the account's public key", http.StatusInternalServerError)
+			return
+		}
+
+		if !pubKey.VerifySignature([]byte(nonce), signature) {
+			http.Error(w, "failed to verification signature", http.StatusBadRequest)
+			return
+		}
+
+		context.Set(r, types.RequesterAddressKey, requesterAddress)
+		next.ServeHTTP(w, r)
+
+		err = amw.generateAuthenticationAndSetHeader(w, sigAuthParts)
+		if err != nil {
+			log.Error("failed to generate authentication", err)
+			http.Error(w, "failed to generate authentication", http.StatusInternalServerError)
+		}
+	})
+}
+
+func (amw *AuthenticationMiddleware) isAuthenticationURL(r *http.Request) bool {
+	for path, methods := range amw.url {
+		ok, err := regexp.MatchString(path, r.URL.Path)
+		if err == nil && ok {
+			if validation.Contains(methods, r.Method) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ParseSignatureAuthorizationParts parses Authorization value in Header according to `Signature` type.
+func ParseSignatureAuthorizationParts(auth string) (map[string]string, error) {
+	if len(auth) < len(prefixType) || !strings.EqualFold(auth[:len(prefixType)], prefixType) {
+		return nil, errors.New("not supported auth type")
+	}
+
+	headers := strings.Split(auth[len(prefixType):], ",")
+	parts := make(map[string]string, len(authorizationHeaders))
+	for _, header := range headers {
+		for _, w := range authorizationHeaders {
+			if strings.Contains(header, w) {
+				parts[w] = strings.Split(header, `"`)[1]
+			}
+		}
+	}
+
+	return parts, nil
+}
+
+func basicValidate(sigAuthParts map[string]string) error {
+	if sigAuthParts[Algorithm] != "es256k1-sha256" {
+		return errors.New(fmt.Sprintf("is not supported value. (Algorithm: %s)", sigAuthParts[Algorithm]))
+	} else if sigAuthParts[KeyId] == "" {
+		return errors.New("'KeyId' cannot be empty")
+	}
+	return nil
+}
+
+func (amw *AuthenticationMiddleware) generateAuthenticationAndSetHeader(w http.ResponseWriter, sigAuthParts map[string]string) error {
+	err := amw.generateAuthentication(sigAuthParts)
+	if err != nil {
+		return err
+	}
+	auth := makeAuthenticationHeader(sigAuthParts)
+
+	w.Header().Set("WWW-Authenticate", auth)
+
+	return nil
+}
+
+func (amw *AuthenticationMiddleware) generateAuthentication(sigAuthParts map[string]string) error {
+	err := setNewNonce(sigAuthParts)
+	if err != nil {
+		return err
+	}
+
+	cache := amw.service.Cache
+	err = cache.Set(sigAuthParts[KeyId], sigAuthParts[Nonce], sigAuthParts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setNewNonce(sigAuthParts map[string]string) error {
+	randomBytes := make([]byte, 24)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return err
+	}
+
+	sigAuthParts[Nonce] = base64.StdEncoding.EncodeToString(randomBytes)
+
+	return nil
+}
+
+func makeAuthenticationHeader(sigAuthParts map[string]string) string {
+	var authenticate []string
+	for _, h := range authenticateHeaders {
+		authenticate = append(authenticate, fmt.Sprintf("%s=\"%s\"", h, sigAuthParts[h]))
+	}
+
+	return prefixType + " " + strings.Join(authenticate, ", ")
+}

--- a/server/middleware/auth/authentication_test.go
+++ b/server/middleware/auth/authentication_test.go
@@ -1,0 +1,210 @@
+package auth_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/gorilla/context"
+	"github.com/medibloc/panacea-data-market-validator/cache"
+	"github.com/medibloc/panacea-data-market-validator/config"
+	"github.com/medibloc/panacea-data-market-validator/panacea"
+	"github.com/medibloc/panacea-data-market-validator/server/middleware/auth"
+	"github.com/medibloc/panacea-data-market-validator/server/service"
+	"github.com/medibloc/panacea-data-market-validator/server/service/datapool"
+	"github.com/medibloc/panacea-data-market-validator/types"
+	"github.com/medibloc/panacea-data-market-validator/types/testutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	requesterPrivKey = secp256k1.GenPrivKey()
+	requesterPubKey  = requesterPrivKey.PubKey()
+	requesterAddress = testutil.GetAddress(requesterPubKey)
+)
+
+func TestParseSignatureAuthorizationNotSupportType(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+	req := httptest.NewRequest(http.MethodGet, "/v0/data-pool/pools/1/data", nil)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
+	require.Equal(t, "not supported auth type\n", recorder.Body.String())
+}
+
+func TestBasicValidateAlgorithmWrong(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+
+	authHeader := makeAuthorizationHeader("es256k1", requesterAddress, "", "")
+	req := httptest.NewRequest(http.MethodGet, "/v0/data-pool/pools/1/data", nil)
+	req.Header.Add("Authorization", authHeader)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "is not supported value. (Algorithm: es256k1)\n", recorder.Body.String())
+}
+
+func TestBasicValidateKeyIdEmpty(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+
+	authHeader := makeAuthorizationHeader("es256k1-sha256", "", "", "")
+	req := httptest.NewRequest(http.MethodGet, "/v0/data-pool/pools/1/data", nil)
+	req.Header.Add("Authorization", authHeader)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, "'KeyId' cannot be empty\n", recorder.Body.String())
+}
+
+func TestParseSignatureAuthenticationParts(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v0/tee/attestation-token", nil)
+	req.Header.Add("Authorization", "Signature\n    keyId=\"panacea1xxxx\",\n    algorithm=\"es256k1-sha256\",\n    nonce=\"\",\n    signature=\"\"")
+
+	parts, err := auth.ParseSignatureAuthorizationParts(req.Header.Get("Authorization"))
+	require.NoError(t, err)
+
+	require.Equal(t, "panacea1xxxx", parts[auth.KeyId])
+	require.Equal(t, "es256k1-sha256", parts[auth.Algorithm])
+	require.Equal(t, "", parts[auth.Nonce])
+	require.Equal(t, "", parts[auth.Signature])
+}
+
+func mockHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Info("Success execute handler")
+		requester := context.Get(r, types.RequesterAddressKey)
+		log.Info("requesterAddress: ", requester)
+	}
+}
+
+func makeMockSvc() *service.Service {
+	conf := config.DefaultConfig()
+	grpcClient := makeMockGrpcClient()
+	return &service.Service{
+		Conf:          conf,
+		Cache:         cache.NewAuthenticationCache(conf),
+		PanaceaClient: grpcClient,
+	}
+}
+
+func makeMockGrpcClient() panacea.GrpcClientI {
+	accounts := []authtypes.AccountI{
+		testutil.NewBaseAccount(requesterPubKey, 0, 0),
+	}
+
+	return testutil.NewMockGrpcClient(
+		accounts,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func makeAuthorizationHeader(algorithm, keyId, nonce, signature string) string {
+	return fmt.Sprintf(
+		"Signature keyId=\"%s\", "+
+			"algorithm=\"%s\", "+
+			"nonce=\"%s\", "+
+			"signature=\"%s\"",
+		keyId,
+		algorithm,
+		nonce,
+		signature,
+	)
+}
+
+func TestEntireAuthenticationProcess(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+
+	algorithm := "es256k1-sha256"
+	authHeader := makeAuthorizationHeader(algorithm, requesterAddress, "", "")
+	req := httptest.NewRequest(http.MethodGet, "/v0/data-pool/pools/1/data", nil)
+	req.Header.Add("Authorization", authHeader)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+	authenticateParts, err := auth.ParseSignatureAuthorizationParts(res.Header.Get("WWW-Authenticate"))
+	require.Equal(t, algorithm, authenticateParts[auth.Algorithm])
+	require.Equal(t, requesterAddress, authenticateParts[auth.KeyId])
+	require.NotEqual(t, "", authenticateParts[auth.Nonce])
+	require.NoError(t, err)
+	nonce := authenticateParts[auth.Nonce]
+	signature, err := requesterPrivKey.Sign([]byte(nonce))
+	require.NoError(t, err)
+
+	authHeader = makeAuthorizationHeader(
+		algorithm,
+		requesterAddress,
+		nonce,
+		base64.StdEncoding.EncodeToString(signature),
+	)
+	req.Header.Set("Authorization", authHeader)
+	recorder = httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res = recorder.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	secondAuthenticateParts, err := auth.ParseSignatureAuthorizationParts(res.Header.Get("WWW-Authenticate"))
+	require.NoError(t, err)
+	require.Equal(t, algorithm, secondAuthenticateParts[auth.Algorithm])
+	require.Equal(t, requesterAddress, secondAuthenticateParts[auth.KeyId])
+	require.Equal(t, authenticateParts[auth.KeyId], secondAuthenticateParts[auth.KeyId])
+	require.NotEqual(t, authenticateParts[auth.Nonce], secondAuthenticateParts[auth.Nonce])
+}
+
+func TestNotIncludeAuthenticationURL(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+
+	algorithm := "es256k1-sha256"
+	authHeader := makeAuthorizationHeader(algorithm, requesterAddress, "", "")
+	req := httptest.NewRequest(http.MethodPost, "/v0/data-pool/pools/1/rounds/{round}/data", nil)
+	req.Header.Add("Authorization", authHeader)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "", res.Header.Get("WWW-Authenticate"))
+}
+
+func TestSameURLDifferentMethod(t *testing.T) {
+	middleware := auth.NewMiddleware(makeMockSvc())
+	datapool.RegisterMiddleware(middleware)
+
+	algorithm := "es256k1-sha256"
+	authHeader := makeAuthorizationHeader(algorithm, requesterAddress, "", "")
+	req := httptest.NewRequest(http.MethodPost, "/v0/data-pool/pools/1/data", nil)
+	req.Header.Add("Authorization", authHeader)
+	recorder := httptest.NewRecorder()
+
+	middleware.Middleware(mockHandler()).ServeHTTP(recorder, req)
+
+	res := recorder.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "", res.Header.Get("WWW-Authenticate"))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	authmiddleware "github.com/medibloc/panacea-data-market-validator/server/middleware/auth"
 	"net/http"
 	"os"
 	"os/signal"
@@ -31,6 +32,10 @@ func Run(conf *config.Config) error {
 	datadeal.RegisterHandlers(svc, router)
 	datapool.RegisterHandlers(svc, router)
 	tee.RegisterHandlers(svc, router)
+
+	middleware := authmiddleware.NewMiddleware(svc)
+	router.Use(middleware.Middleware)
+	datapool.RegisterMiddleware(middleware)
 
 	server := &http.Server{
 		Handler:      router,

--- a/server/service/datapool/download_data_handler.go
+++ b/server/service/datapool/download_data_handler.go
@@ -1,10 +1,16 @@
 package datapool
 
 import (
+	"github.com/gorilla/context"
+	"github.com/medibloc/panacea-data-market-validator/types"
 	"net/http"
 )
 
 func (svc *dataPoolService) handleDownloadData(writer http.ResponseWriter, request *http.Request) {
-	//TODO implement me
+	requesterAddress := context.Get(request, types.RequesterAddressKey)
+	if requesterAddress != request.FormValue("requester_address") {
+		http.Error(writer, "Do not matched signer and requester", http.StatusBadRequest)
+		return
+	}
 	panic("implement me")
 }

--- a/server/service/datapool/service.go
+++ b/server/service/datapool/service.go
@@ -1,10 +1,11 @@
 package datapool
 
 import (
+	"github.com/medibloc/panacea-data-market-validator/server/service"
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/medibloc/panacea-data-market-validator/server/service"
+	authmiddleware "github.com/medibloc/panacea-data-market-validator/server/middleware/auth"
 )
 
 type dataPoolService struct {
@@ -18,4 +19,8 @@ func RegisterHandlers(svc *service.Service, router *mux.Router) {
 
 	router.HandleFunc("/v0/data-pool/pools/{poolId}/rounds/{round}/data", s.handleValidateData).Methods(http.MethodPost)
 	router.HandleFunc("/v0/data-pool/pools/{poolId}/data", s.handleDownloadData).Methods(http.MethodGet)
+}
+
+func RegisterMiddleware(auth *authmiddleware.AuthenticationMiddleware) {
+	auth.AddURL("/v0/data-pool/pools/{poolId}/data", http.MethodGet)
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -3,27 +3,28 @@ package service
 import (
 	"crypto/tls"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/edgelesssys/ego/ecrypto"
 	datapooltypes "github.com/medibloc/panacea-core/v2/x/datapool/types"
+	"github.com/medibloc/panacea-data-market-validator/cache"
 	"github.com/medibloc/panacea-data-market-validator/config"
 	"github.com/medibloc/panacea-data-market-validator/crypto"
 	"github.com/medibloc/panacea-data-market-validator/panacea"
 	"github.com/medibloc/panacea-data-market-validator/store"
 	"github.com/medibloc/panacea-data-market-validator/tee"
 	tos "github.com/tendermint/tendermint/libs/os"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 type Service struct {
 	Conf             *config.Config
 	ValidatorAccount *panacea.ValidatorAccount
 	Store            store.Storage
-	PanaceaClient    *panacea.GrpcClient
+	PanaceaClient    panacea.GrpcClientI
 	TLSCert          *tls.Certificate
 	DataEncKey       []byte
+	Cache            *cache.AuthenticationCache
 }
 
 func New(conf *config.Config) (*Service, error) {
@@ -66,6 +67,8 @@ func New(conf *config.Config) (*Service, error) {
 		return nil, err
 	}
 
+	authenticateCache := cache.NewAuthenticationCache(conf)
+
 	return &Service{
 		Conf:             conf,
 		ValidatorAccount: validatorAccount,
@@ -73,6 +76,7 @@ func New(conf *config.Config) (*Service, error) {
 		PanaceaClient:    panaceaClient,
 		TLSCert:          tlsCert,
 		DataEncKey:       key,
+		Cache:            authenticateCache,
 	}, nil
 }
 

--- a/types/auth/authentication.go
+++ b/types/auth/authentication.go
@@ -1,8 +1,22 @@
 package auth
 
+import (
+	"fmt"
+	"strings"
+)
+
 type SignatureAuthentication struct {
 	Algorithm string
 	KeyId     string
 	Nonce     string
 	Signature string
+}
+
+func (m *SignatureAuthentication) ToWWWAuthenticateValue() string {
+	s := []string{
+		fmt.Sprintf("algorithm=%s", m.Algorithm),
+		fmt.Sprintf("keyId=%s", m.Algorithm),
+		fmt.Sprintf("nonce=%s", m.Algorithm),
+	}
+	return strings.Join(s, ", ")
 }

--- a/types/keys.go
+++ b/types/keys.go
@@ -1,6 +1,7 @@
 package types
 
 const (
-	DealIDKey = "dealId"
-	PoolIDKey = "poolId"
+	DealIDKey           = "dealId"
+	PoolIDKey           = "poolId"
+	RequesterAddressKey = "requesterAccount"
 )

--- a/types/testutil/account.go
+++ b/types/testutil/account.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/medibloc/panacea-data-market-validator/panacea"
+)
+
+func GetAddress(pubKey cryptotypes.PubKey) string {
+	address, err := bech32.ConvertAndEncode(panacea.AccountAddressPrefix, pubKey.Address())
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+func NewBaseAccount(pubKey cryptotypes.PubKey, accountNumber, sequence uint64) *authtypes.BaseAccount {
+	acc := authtypes.BaseAccount{
+		Address:       GetAddress(pubKey),
+		AccountNumber: accountNumber,
+		Sequence:      sequence,
+	}
+	err := acc.SetPubKey(pubKey)
+	if err != nil {
+		panic(err)
+	}
+
+	return &acc
+}

--- a/types/testutil/grpc_client.go
+++ b/types/testutil/grpc_client.go
@@ -1,0 +1,99 @@
+package testutil
+
+import (
+	"errors"
+	"github.com/cosmos/cosmos-sdk/crypto/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	datadealtypes "github.com/medibloc/panacea-core/v2/x/datadeal/types"
+	datapooltypes "github.com/medibloc/panacea-core/v2/x/datapool/types"
+	log "github.com/sirupsen/logrus"
+	"strconv"
+)
+
+type MockGrpcClient struct {
+	accountMap      map[string]authtypes.AccountI
+	dealMap         map[string]datadealtypes.Deal
+	poolMap         map[string]datapooltypes.Pool
+	regValidatorMap map[string]datapooltypes.DataValidator
+}
+
+func NewMockGrpcClient(
+	accounts []authtypes.AccountI,
+	deals []datadealtypes.Deal,
+	pools []datapooltypes.Pool,
+	regValidators []datapooltypes.DataValidator,
+) MockGrpcClient {
+	cli := MockGrpcClient{
+		accountMap:      make(map[string]authtypes.AccountI),
+		dealMap:         make(map[string]datadealtypes.Deal),
+		poolMap:         make(map[string]datapooltypes.Pool),
+		regValidatorMap: make(map[string]datapooltypes.DataValidator),
+	}
+	if len(accounts) > 0 {
+		for _, account := range accounts {
+			cli.accountMap[GetAddress(account.GetPubKey())] = account
+		}
+	}
+	if len(deals) > 0 {
+		for _, deal := range deals {
+			cli.dealMap[strconv.FormatUint(deal.DealId, 10)] = deal
+		}
+	}
+	if len(pools) > 0 {
+		for _, pool := range pools {
+			cli.poolMap[strconv.FormatUint(pool.PoolId, 10)] = pool
+		}
+	}
+	if len(regValidators) > 0 {
+		for _, regVal := range regValidators {
+			cli.regValidatorMap[regVal.GetAddress()] = regVal
+		}
+	}
+
+	return cli
+}
+
+func (m MockGrpcClient) GetAccount(panaceaAddr string) (authtypes.AccountI, error) {
+	acc, ok := m.accountMap[panaceaAddr]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return acc, nil
+}
+
+func (m MockGrpcClient) GetDeal(id string) (datadealtypes.Deal, error) {
+	deal, ok := m.dealMap[id]
+	if !ok {
+		return datadealtypes.Deal{}, errors.New("not found")
+	}
+	return deal, nil
+}
+
+func (m MockGrpcClient) GetRegisteredDataValidator(address string) (*datapooltypes.DataValidator, error) {
+	regVal, ok := m.regValidatorMap[address]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &regVal, nil
+}
+
+func (m MockGrpcClient) GetPool(id string) (datapooltypes.Pool, error) {
+	pool, ok := m.poolMap[id]
+	if !ok {
+		return datapooltypes.Pool{}, errors.New("not found")
+	}
+	return pool, nil
+}
+
+func (m MockGrpcClient) Close() error {
+	log.Info("Call Close()")
+	return nil
+}
+
+func (m MockGrpcClient) GetPubKey(panaceaAddr string) (types.PubKey, error) {
+	addr, err := m.GetAccount(panaceaAddr)
+	if err != nil {
+		return nil, err
+	}
+	return addr.GetPubKey(), nil
+}


### PR DESCRIPTION
### Two main things have been added.
* Added mock for simple grpcClient.
* Added middleware for authentication.

### The authentication process is as follows.
* Check if the URL requires authentication.
  * If authentication is not required, not checked a authentication
* Extract the Authorization value from the request header and parse it.
  * If parsing failed, it responds with a bad request.(status: 400)
* Perform a check value on the extracted header.
  * If the algorithm is wrong or the keyId is empty, then returned a bad request.(status: 400)
* If the nonce is empty, authentication request information must be sent to the client, so a new nonce is issued and returned.
  * Nonce forms a key in pair with keyId, and authentication can proceed according to the time set in config. (default 10 seconds)
* If the nonce has expired but the client makes an authentication request with this nonce, it responds with `UnAuthenticate(401)` and issues a new nonce.
* If the nonce has not expired, the signature must be verified.
  * This signature is verified after obtaining the PublicKey from the block chain with the address obtained from the keyId.
* If signature verification fails, a `BadRequest(400)` err is returned.
* When all verification passed, it is recorded in the context so that the signer information can be known inside the handler.
* After executing handler, it responds by create a new nonce again.