### PR TITLE
chore: add info level log of successful response

### DIFF
--- a/server/service/datadeal/validate_data_handler.go
+++ b/server/service/datadeal/validate_data_handler.go
@@ -134,7 +134,6 @@ func (svc *dataDealService) handleValidateData(w http.ResponseWriter, r *http.Re
 	}
 
 	log.Infof("data validation completed for deal %s: %s", dealID, base64.StdEncoding.EncodeToString(dataHash))
-
 	response.WriteJSONResponse(w, http.StatusCreated, marshaledResp)
 }
 

--- a/server/service/datapool/download_data_handler.go
+++ b/server/service/datapool/download_data_handler.go
@@ -111,6 +111,8 @@ func (svc *dataPoolService) handleDownloadData(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	log.Infof("pool %d data downloaded to %s", poolID, redeemer)
+
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"pool-%d.zip\"", poolID))
 

--- a/server/service/datapool/validate_data_handler.go
+++ b/server/service/datapool/validate_data_handler.go
@@ -126,7 +126,6 @@ func (svc *dataPoolService) handleValidateData(w http.ResponseWriter, r *http.Re
 	}
 
 	log.Infof("data validation completed for pool %s: %s", poolID, base64.StdEncoding.EncodeToString(dataHash))
-
 	response.WriteJSONResponse(w, http.StatusCreated, marshaledResp)
 }
 

--- a/server/service/datapool/validate_data_handler.go
+++ b/server/service/datapool/validate_data_handler.go
@@ -125,6 +125,8 @@ func (svc *dataPoolService) handleValidateData(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	log.Infof("data validation completed for pool %s: %s", poolID, base64.StdEncoding.EncodeToString(dataHash))
+
 	response.WriteJSONResponse(w, http.StatusCreated, marshaledResp)
 }
 

--- a/server/service/tee/token_handler.go
+++ b/server/service/tee/token_handler.go
@@ -26,7 +26,7 @@ func (svc *teeService) handleToken(writer http.ResponseWriter, request *http.Req
 		http.Error(writer, "failed to create attestation token", http.StatusInternalServerError)
 		return
 	}
-	log.Debugf("Azure attestation token created: %v", jwt)
+	log.Infof("Azure attestation token created: %v", jwt)
 
 	writer.WriteHeader(http.StatusOK)
 	writer.Header().Set("Content-Type", "application/jwt")


### PR DESCRIPTION
There was no log when oracle node responded normally, so added with log level of `Info`.